### PR TITLE
北海道の一部の自治体で使われているn線(nは数字)の正規化に対応

### DIFF
--- a/src/imi-enrichment-address/lib/util.js
+++ b/src/imi-enrichment-address/lib/util.js
@@ -170,6 +170,13 @@ const Util = {
       name = name.replace(`${original}条`, `${normalized}条`)
     }
 
+    // 数字「線」を感数字に（旭川市など）
+    if (name.match(/^.*?(([0-9]+|[０-９]+)(線))/)) {
+      const original = RegExp.$2
+      const normalized = Util.h2j(Util.z2h(original))
+      name = name.replace(`${original}線`, `${normalized}線`)
+    }
+
     // 数字丁を漢数字に（堺市）
     if (name.match(/^.*?(([0-9]+|[０-９]+)(丁(?!目)))/)) {
       const original = RegExp.$2

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -33,4 +33,8 @@ describe('Tests for `src/imi-enrichment-address/lib/util.js`.', () => {
     const normalized = util.normalize("大阪府大阪市北区梅田１丁目２")
     assert.deepEqual("大阪府大阪市北区梅田一丁目２", normalized)
   });
+  it('should normalize address "北海道上川郡鷹栖町9線6号".', () => {
+    const normalized = util.normalize("北海道上川郡鷹栖町9線6号")
+    assert.deepEqual("北海道上川郡鷹栖町九線6号", normalized)
+  })
 })


### PR DESCRIPTION
旭川市、や川上郡で使われている n線 の表記の正規化に対応しました。
close #31