### PR TITLE
「重複する 町名・村名」+「大字・字」のケースで住所データを適切に取得できないバグを修正(#91)

### DIFF
--- a/src/imi-enrichment-address/lib/find.js
+++ b/src/imi-enrichment-address/lib/find.js
@@ -172,14 +172,60 @@ const find = address => {
     }
   }
 
+  /**
+   * 「重複する 町名・村名」+「大字・字」の検索時に指定の住所データを取得
+   * @param {string} normalized
+   * @param {*} answer
+   */
+  const getUniqueAddressFromSameName = (normalized, answer) => {
+
+    const uniqueAddressIndex = answer.findIndex( singleAnswer => {
+
+      if (!singleAnswer.children && singleAnswer.label === normalized) {
+        return false
+      }
+
+      // 重複している町村名以下を取得
+      const regExp = new RegExp( singleAnswer.label, 'g' )
+      normalized = normalized.replace( regExp, '' )
+
+      let match
+      for (let i = 0; i < singleAnswer.children.length; i++) {
+        // 大字・字・字なしの条件でチェック
+        let child = singleAnswer.children[i]
+        if (child.label === normalized || child.label === `大字${normalized}` || child.label === `字${normalized}`) {
+          match = true
+          break
+        } else {
+          match = false
+        }
+      }
+      return match
+    })
+
+    if (-1 === uniqueAddressIndex) {
+      return answer
+    } else {
+      return [answer[uniqueAddressIndex]]
+    }
+  }
+
   // 市区町村にヒットする場合
   for (let i = normalized.length; i >= 0; i--) {
     const head = normalized.substring(0, i)
-    const answer = upper[head]
+    let answer = upper[head]
+
     if (typeof answer !== 'undefined') {
+
       if (answer.length > 1) {
-        return {
-          multipleChoice: true,
+
+        // 大字を追加して再検索
+        answer = getUniqueAddressFromSameName(normalized, answer)
+
+        if (answer.length > 1) {
+          return {
+            multipleChoice: true,
+          }
         }
       }
 

--- a/test/find.spec.js
+++ b/test/find.spec.js
@@ -292,4 +292,26 @@ describe('Tests for `src/imi-enrichment-address/lib/find.js`.', () => {
     assert.deepEqual('131010049003', res.code)
     assert.deepEqual('', res.tail) // 内部的に `之` を `の` に変換
   })
+
+  // https://github.com/geolonia/community-geocoder/issues/91
+  it('should find the address "高山村高井" as expected.', () => {
+    const res = find(util.normalize("高山村高井"))
+    assert.deepEqual('205430002000', res.code)
+    assert.deepEqual('', res.tail)
+  })
+  it('should find the address "高山村大字高井" as expected.', () => {
+    const res = find(util.normalize("高山村大字高井"))
+    assert.deepEqual('205430002000', res.code)
+    assert.deepEqual('', res.tail)
+  })
+  it('should find the address "森町赤井川" as expected.', () => {
+    const res = find(util.normalize("森町赤井川"))
+    assert.deepEqual('013450001000', res.code)
+    assert.deepEqual('', res.tail)
+  })
+  it('should find the address "森町字赤井川" as expected.', () => {
+    const res = find(util.normalize("森町字赤井川"))
+    assert.deepEqual('013450001000', res.code)
+    assert.deepEqual('', res.tail)
+  })
 })


### PR DESCRIPTION
Fix geolonia/community-geocoder#91 

高山村は長野県と群馬県にあるため「高山村高井」を検索するケースでは、2つのデータを取得してしまいエラーになる。

なので重複する「重複する 町名・村名」+「大字・字」のケースでは、大字・字も検索対象に追加。

