### PR TITLE
通り名をうまく検出できないケースに対応: 町名が正規化を経ている場合

### DIFF
--- a/src/imi-enrichment-address/lib/find.js
+++ b/src/imi-enrichment-address/lib/find.js
@@ -248,20 +248,21 @@ const find = address => {
         let match = ''
         for (let k = 0; k < children.length; k++) {
           const item = children[k]
-          const index = normalized.substring(i).lastIndexOf(item.label)
+          const label = dict(item.label)
+          const index = normalized.substring(i).lastIndexOf(label)
 
           if (0 <= index) {
-            if (match && 0 <= item.label.indexOf(match)) { // https://github.com/geolonia/community-geocoder/issues/37
-              const parts = normalized.substring(i).split(item.label)
+            if (match && 0 <= label.indexOf(match)) { // https://github.com/geolonia/community-geocoder/issues/37
+              const parts = normalized.substring(i).split(label)
               result.code = `${item.code}${( Array(3).join('0') + item.chome ).slice( -3 )}`
-              result.normalized = `京都府京都市${answer[0].label}${item.label}${parts[parts.length - 1]}`
+              result.normalized = `京都府京都市${answer[0].label}${label}${parts[parts.length - 1]}`
               result.answer = item
             } else {
               if (index > lastIndex) { // See https://github.com/geolonia/community-geocoder/issues/10
                 lastIndex = index
-                const parts = normalized.substring(i).split(item.label)
+                const parts = normalized.substring(i).split(label)
                 result.code = `${item.code}${( Array(3).join('0') + item.chome ).slice( -3 )}`
-                result.normalized = `京都府京都市${answer[0].label}${item.label}${parts[parts.length - 1]}`
+                result.normalized = `京都府京都市${answer[0].label}${label}${parts[parts.length - 1]}`
                 result.answer = item
               }
             }

--- a/src/imi-enrichment-address/lib/find.js
+++ b/src/imi-enrichment-address/lib/find.js
@@ -248,21 +248,21 @@ const find = address => {
         let match = ''
         for (let k = 0; k < children.length; k++) {
           const item = children[k]
-          const label = dict(item.label)
-          const index = normalized.substring(i).lastIndexOf(label)
+          const normalizedLabel = dict(item.label)
+          const index = normalized.substring(i).lastIndexOf(normalizedLabel)
 
           if (0 <= index) {
-            if (match && 0 <= label.indexOf(match)) { // https://github.com/geolonia/community-geocoder/issues/37
-              const parts = normalized.substring(i).split(label)
+            if (match && 0 <= normalizedLabel.indexOf(match)) { // https://github.com/geolonia/community-geocoder/issues/37
+              const parts = normalized.substring(i).split(normalizedLabel)
               result.code = `${item.code}${( Array(3).join('0') + item.chome ).slice( -3 )}`
-              result.normalized = `京都府京都市${answer[0].label}${label}${parts[parts.length - 1]}`
+              result.normalized = `京都府京都市${answer[0].label}${normalizedLabel}${parts[parts.length - 1]}`
               result.answer = item
             } else {
               if (index > lastIndex) { // See https://github.com/geolonia/community-geocoder/issues/10
                 lastIndex = index
-                const parts = normalized.substring(i).split(label)
+                const parts = normalized.substring(i).split(normalizedLabel)
                 result.code = `${item.code}${( Array(3).join('0') + item.chome ).slice( -3 )}`
-                result.normalized = `京都府京都市${answer[0].label}${label}${parts[parts.length - 1]}`
+                result.normalized = `京都府京都市${answer[0].label}${normalizedLabel}${parts[parts.length - 1]}`
                 result.answer = item
               }
             }

--- a/test/find.spec.js
+++ b/test/find.spec.js
@@ -314,4 +314,11 @@ describe('Tests for `src/imi-enrichment-address/lib/find.js`.', () => {
     assert.deepEqual('013450001000', res.code)
     assert.deepEqual('', res.tail)
   })
+  // https://github.com/geolonia/community-geocoder/issues/84
+  it('should find the address', () => {
+    const res = find(util.normalize("京都府京都市上京区中長者町通新町西入仲之町276"))
+    // const res = find(util.normalize("京都府京都市上京区仲之町"))
+    assert.deepEqual('261020357000', res.code) // 中長者町通新町西入 を削除
+    assert.deepEqual('276', res.tail)
+  })
 })

--- a/test/find.spec.js
+++ b/test/find.spec.js
@@ -317,7 +317,6 @@ describe('Tests for `src/imi-enrichment-address/lib/find.js`.', () => {
   // https://github.com/geolonia/community-geocoder/issues/84
   it('should find the address', () => {
     const res = find(util.normalize("京都府京都市上京区中長者町通新町西入仲之町276"))
-    // const res = find(util.normalize("京都府京都市上京区仲之町"))
     assert.deepEqual('261020357000', res.code) // 中長者町通新町西入 を削除
     assert.deepEqual('276', res.tail)
   })


### PR DESCRIPTION
例: 京都府京都市上京区中長者町通新町西入仲之町276

上記のように「上京区」と「仲之町」に挟まれた住所は、町名が「仲の町」に正規化されているので通り名を検出できていませんでした。検出の際にデータソースの町名も正規化することにし、正しく検出できるようにしました。
