### PR TITLE
CI を Node 20/22/24 のマトリックスに更新し、Node 20 以降で落ちていたテストを修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -12,10 +15,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # 22.x と 24.x が現行のサポート対象。
+        # 20.x は 2026-04-30 に EOL 済みだが、利用者の移行猶予のため
+        # レガシー互換性の確認として当面残す。
+        # 依存を Babel 8 系に上げる際は engines が Node 22 以上を要求するため
+        # 20.x を外す判断が必要になる。
         node-version: [20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          # PR のコードに対して npm ci や npm test を実行するため、
+          # .git/config に GITHUB_TOKEN を残さない。
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,26 +2,26 @@ name: Build
 on:
   pull_request:
     branches: [master]
+  push:
+    branches: [master]
 
 jobs:
   test:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Cache node_modules
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: modules-cache-v1-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          cache: npm
 
       - run: npm ci
       - run: npm test
+      - run: npm run build

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "webpack-dev-server --mode development --config ./docs/webpack.config.js",
     "build": "webpack --mode=production --config ./webpack.config.js",
     "test": "npm run test:lint && npm run test:mocha ./test/**/*.spec.js",
-    "test:lint": "eslint \"src/**/*.js\" --fix",
+    "test:lint": "eslint \"src/**/*.js\"",
+    "lint:fix": "eslint \"src/**/*.js\" --fix",
     "test:mocha": "mocha --require @babel/register",
     "test:addresses": "npm run test:mocha ./test/addresses.js"
   },

--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,4 @@
-const { normalize } = require('@geolonia/normalize-japanese-addresses')
+import { normalize } from '@geolonia/normalize-japanese-addresses'
 
 export const getLatLng = (str, callback, errorCallback = () => {}) => {
   try {

--- a/src/app.js
+++ b/src/app.js
@@ -1,8 +1,9 @@
 import geojsonExtent from '@mapbox/geojson-extent'
+import viewportUnitsBuggyfill from 'viewport-units-buggyfill'
 
 import { getLatLng } from './api.js'
 
-require('viewport-units-buggyfill').init()
+viewportUnitsBuggyfill.init()
 
 document.addEventListener('DOMContentLoaded', () => {
   const map = new window.geolonia.Map('#map')
@@ -74,7 +75,7 @@ document.addEventListener('DOMContentLoaded', () => {
               value.prefecture === latlng.pref && (
                 value.city === latlng.city ||
                 latlng.city.endsWith(`郡${value.city}`) // 郡名が含まれていないため
-              )
+              ),
             )
             const code = keys[index].substr(0, 5)
 


### PR DESCRIPTION
## 概要

CI のマトリックスから EOL 済みの Node 16 / 18 を外し、20.x / 22.x / 24.x に入れ替えます。あわせて、Node 20 以降ではそもそもテストが通らない状態になっていたので、その原因も直しています。

## Node 20 以降でテストが落ちていた理由

`src/api.js` が `require()` と `export` を混在させており、`@babel/register` (CommonJS の require フック) による変換が前提になっていました。Node 20.19 以降は module type の自動判定がデフォルトで有効になっており、`type` 未指定の `.js` に `import`/`export` があると ESM として再パースされます。すると require フックを通らないまま読み込まれ、`ReferenceError: require is not defined in ES module scope` で落ちます。Node 18 以前にはこの判定がないため通っていた、というだけでした。

`src/api.js` と `src/app.js` に残っていた `require()` を `import` に統一して解消しています。`package.json` に `"type": "commonjs"` を足す案も試しましたが、webpack が babel-loader の出力する `import` 文を CommonJS として解釈できずビルドが壊れるため採用していません。

## その他の変更

- `test:lint` から `--fix` を外し、`lint:fix` として分離しました。CI で `--fix` が走ると lint 違反を黙って修正して緑になってしまうためです。実際、`src/app.js` は `comma-dangle` 違反を抱えたまま CI が通っていたので、あわせて修正しています。
- node_modules の手動キャッシュを `setup-node` の `cache: npm` に置き換えました。キーに Node バージョンが含まれておらず、全マトリックスジョブが同じ node_modules を共有する状態になっていました。
- `actions/checkout` と `actions/setup-node` を v7 に更新しました。
- master への push でも CI が走るようにし、`fail-fast: false` で 1 バージョンの失敗が他を隠さないようにしました。
- `npm run build` を CI に追加しました。ワークフロー名が Build でありながらビルドを実行していなかったためです。

## 動作確認

Node 20.19.0 / 22.23.1 / 24.16.0 の 3 バージョンで、クリーンな `npm ci` から `npm test` と `npm run build` まで通ることを手元で確認済みです。

## 補足: 依存の更新について

現状 `npm audit` で 53 件 (critical 22 件) 検出されます。critical はすべて `babel-preset-env@1.7.0` 由来です。これは Babel 6 時代のパッケージで、`.babelrc` は `@babel/preset-env` を使っているため実際には未使用です。

#171 が入れようとしている `@babel/core` 8 系と `webpack-dev-server` 6 は engines がそれぞれ `^22.18.0 || >=24.11.0` と `>= 22.15.0` で、Node 20 では動きません。依存の近代化を進める際は Node 20 を外すかどうかの判断が必要になります。あわせて eslint 10 への移行 (`.eslintrc.js` から `eslint.config.js` へ) と Babel 8 での `useBuiltIns` 廃止対応も必要です。これらは別 PR で対応します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - 対応する Node.js のバージョンを更新し、複数環境でのビルド・テスト確認を強化しました。
  - ビルド処理を自動検証に追加しました。
  - 自動検証の継続性と安全性を向上しました。

- **開発体験**
  - コード検査と自動修正のコマンドを分離し、用途に応じて実行できるようにしました。
  - モジュール読み込み方式を統一し、実行時の安定性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->